### PR TITLE
Create AlumniCard Component

### DIFF
--- a/src/components/alumni/AlumniCard.tsx
+++ b/src/components/alumni/AlumniCard.tsx
@@ -19,16 +19,13 @@ const AlumniCard = ({
 }: AlumniCardProps) => {
   return (
     <div className="flex w-1/3 flex-col items-center p-6 text-center">
-      <Image src={image} alt={name} className="mx-auto mb-4 rounded-full" />
+      <Image src={image} alt={name} className="mb-4 rounded-full" />
 
-      <div className="mb-2 text-center text-xl">{name}</div>
+      <div className="mb-2 text-xl">{name}</div>
 
-      <div className="text-hcg-dark-gray mb-2 text-center font-normal">
-        {role}
-      </div>
+      <div className="text-hcg-dark-gray mb-2 font-normal">{role}</div>
 
-      {/* The basis-<number> style acts as a minimum height for flexbox items */}
-      <div className="text-hcg-dark-gray mb-4 basis-6">{currentOccupation}</div>
+      <div className="text-hcg-dark-gray mb-4">{currentOccupation}</div>
 
       <Link href={linkedin} target="_blank">
         <FaLinkedin className="text-hcg-gold h-8 w-8" />


### PR DESCRIPTION
Fixes #59

Created reusable component AlumniCard to display members who had been a part of HCG.

## NOTE
The card's [```currentOccupation```](https://github.com/acm-ucr/hcg-website/blob/272e45674b4602f4ccd0e7d6b33e977ec7e50f67/src/components/alumni/AlumniCard.tsx#L9) property is optional since it doesn't always show up on the website. There are a few layouts to choose from here.

## AlumniCard Screenshots
<img width="560" height="710" alt="card-with-text" src="https://github.com/user-attachments/assets/b5577d19-1e1b-4baf-ab75-8a56dff4642a" />

<img width="560" height="710" alt="card-without-text" src="https://github.com/user-attachments/assets/9fcea0c1-7a8e-4062-aceb-9b6acdeeb04c" />

## From HCG Current Website
[HCG Alumni Page](https://www.highlanderconsultinggroup.org/our-team-1)

<img width="1064" height="669" alt="real-example" src="https://github.com/user-attachments/assets/76d33397-f8fa-476d-b865-0ad0d04de87d" />
